### PR TITLE
Removes the `bottle :unneeded` command

### DIFF
--- a/Formula/gsts.rb
+++ b/Formula/gsts.rb
@@ -7,8 +7,6 @@ class Gsts < Formula
   sha256 "88623e4bcad5890c1901d65e831eeddc266656083bbf5f273e05689faba7468f"
   license "MIT"
 
-  bottle :unneeded
-
   depends_on "node"
 
   def install

--- a/Formula/mota.rb
+++ b/Formula/mota.rb
@@ -7,7 +7,6 @@ class Mota < Formula
   homepage "https://github.com/ruimarinho/mota"
   version "2.0.1"
   license "MIT"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/ruimarinho/mota/releases/download/v2.0.1/mota_2.0.1_macOS_x86_64.tar.gz"


### PR DESCRIPTION
Running `brew audit` shows this command is no longer supported (and that there is no replacement.)